### PR TITLE
Fixing header search paths for iOS

### DIFF
--- a/ios/RCTLocale.xcodeproj/project.pbxproj
+++ b/ios/RCTLocale.xcodeproj/project.pbxproj
@@ -133,7 +133,7 @@
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/../../React/**",
-					"$(SRCROOT)/../react-native/React/**",
+					"$(SRCROOT)/../../react-native/React/**",
 					"$(SRCROOT)/node_modules/react-native/React/**",
 				);
 			};
@@ -144,7 +144,7 @@
 			buildSettings = {
 				HEADER_SEARCH_PATHS = (
 					"$(SRCROOT)/../../React/**",
-					"$(SRCROOT)/../react-native/React/**",
+					"$(SRCROOT)/../../react-native/React/**",
 					"$(SRCROOT)/node_modules/react-native/React/**",
 				);
 			};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-locale",
-  "version": "0.0.12",
+  "version": "0.0.13",
   "description": "Simple locale information and methods for react native",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The native library part of my React Native project running on iOS didn't compile in Xcode because of what looked like a missing "../" component in the header search path to React Native directory. This fixes the issue.