### PR TITLE
Remove Override on deprecated createJSModules method

### DIFF
--- a/android/src/main/java/io/fixd/rctlocale/RCTLocalePackage.java
+++ b/android/src/main/java/io/fixd/rctlocale/RCTLocalePackage.java
@@ -24,7 +24,7 @@ public class RCTLocalePackage implements ReactPackage {
         return modules;
     }
 
-    @Override
+    // Deprecated in React Native 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
This commit removes the Override on the createJSModules() method. This method is no longer required in React Native 0.47. React native apps cannot build without removing this.