### PR TITLE
Updated build.gradle to fix Android build warnings

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.1"
 
     defaultConfig {
         minSdkVersion 16
@@ -20,5 +19,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.17.+'
+    implementation 'com.facebook.react:react-native:0.17.+'
 }


### PR DESCRIPTION
buildToolsVersion is just ignored on by later versions of AGP. As is, It generates the following warning:
```
The specified Android SDK Build Tools version (23.0.1) is ignored, as it is below the minimum supported version (27.0.3) for Android Gradle Plugin 3.1.4.
Android SDK Build Tools 27.0.3 will be used.
To suppress this warning, remove "buildToolsVersion '23.0.1'" from your build.gradle file, as each version of the Android Gradle Plugin now has a default version of the build tools.
```

compile is deprecated and is therefore replaced. As is, It generates the following warning:
```
Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
```