### PR TITLE
Become compatible with React Native v0.59

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,16 @@
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion safeExtGet('compileSdkVersion', 23)
+    buildToolsVersion safeExtGet('buildToolsVersion', "23.0.1")
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 22)
         versionCode 1
         versionName "1.0"
     }
@@ -20,5 +24,5 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.17.+'
+    implementation 'com.facebook.react:react-native:0.17.+'
 }


### PR DESCRIPTION
React Native v0.59 uses a new version of the Android SDK that is incompatible with the one in this library, producing build failures. Using the `rootProject` setting means this library will automatically work with a broad range of React Native versions, so this shouldn't be a breaking change.